### PR TITLE
受講生登録機能（POSTリクエスト）を実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,0 +1,64 @@
+package raisetech.student.management.controller;
+
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.domain.StudentDetail;
+import raisetech.student.management.model.services.StudentService;
+
+@Controller
+public class StudentController {
+
+  private final StudentService service;
+  private final StudentConverter converter;
+
+  public StudentController(StudentService service, StudentConverter converter) {
+    this.service = service;
+    this.converter = converter;
+  }
+
+  @GetMapping("/studentList")
+  public String getStudentList(Model model) {
+    List<Student> students = service.searchStudentList();
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+    List<StudentDetail> studentsDetails = converter.convertStudentDetails(students,
+        studentsCourses);
+
+    model.addAttribute("studentList", studentsDetails);
+    return "studentList";
+  }
+
+  @GetMapping("/studentCourseList")
+  public String getStudentCourseList(Model model) {
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+
+    model.addAttribute("studentCourseList", studentsCourses);
+    return "studentCourseList"; // studentCourseList.htmlを指す。
+  }
+
+  @GetMapping("/newStudent")
+  public String newStudent(Model model) {
+    model.addAttribute("studentDetail", new StudentDetail()); //StudentDetailの要素を登録フォームに適用できるようにする
+    return "registerStudent";
+  }
+
+  @PostMapping("/registerStudent")
+  // ビューの登録フォームで入力されたstudentDetailの情報をstudentServiceに送る
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+
+    // フォームで入力されたstudentDetailのstudentの情報とstudentCourseの情報（最初の一つ）をserviceにあるregisterStudentメソッドの引数とする
+    service.registerStudent(studentDetail.getStudent(),
+        studentDetail.getStudentCourse().getFirst());
+    return "redirect:/studentList";
+  }
+}

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -24,7 +24,7 @@ public class StudentController {
     this.converter = converter;
   }
 
-  @GetMapping("/studentList")
+  @GetMapping("/students")
   public String getStudentList(Model model) {
     List<Student> students = service.searchStudentList();
     List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
@@ -35,7 +35,7 @@ public class StudentController {
     return "studentList";
   }
 
-  @GetMapping("/studentCourseList")
+  @GetMapping("/students-courses")
   public String getStudentCourseList(Model model) {
     List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
 
@@ -43,13 +43,13 @@ public class StudentController {
     return "studentCourseList"; // studentCourseList.htmlを指す。
   }
 
-  @GetMapping("/newStudent")
+  @GetMapping("/students/new")
   public String newStudent(Model model) {
     model.addAttribute("studentDetail", new StudentDetail()); //StudentDetailの要素を登録フォームに適用できるようにする
     return "registerStudent";
   }
 
-  @PostMapping("/registerStudent")
+  @PostMapping("/students")
   // ビューの登録フォームで入力されたstudentDetailの情報をstudentServiceに送る
   public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
     if (result.hasErrors()) {
@@ -59,6 +59,6 @@ public class StudentController {
     // フォームで入力されたstudentDetailのstudentの情報とstudentCourseの情報（最初の一つ）をserviceにあるregisterStudentメソッドの引数とする
     service.registerStudent(studentDetail.getStudent(),
         studentDetail.getStudentCourse().getFirst());
-    return "redirect:/studentList";
+    return "redirect:/students";
   }
 }

--- a/src/main/java/raisetech/student/management/model/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/model/repository/StudentRepository.java
@@ -1,0 +1,42 @@
+package raisetech.student.management.model.repository;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+
+/**
+ * 受講生および受講生コースの情報をDBから取得する。
+ */
+@Mapper
+public interface StudentRepository {
+
+  /**
+   * @return データベースから受講生の情報を全件取得する。
+   */
+  @Select("SELECT * FROM students")
+  List<Student> search();
+
+  /**
+   * @return データベースから受講生のコース情報を全件取得する。
+   */
+  @Select("SELECT * FROM students_courses")
+  List<StudentCourse> searchStudentsCourses();
+
+  /**
+   * @return 受講生の情報をデータベースに登録する。
+   */
+  @Insert("INSERT students values(#{id}, #{fullname}, #{furigana}, #{nickname}, #{mail}, #{address}, #{age}, #{gender}, #{remark}, #{isDeleted})")
+  // ↓SQLで自動生成されたidをStudentオブジェクトのidとして仕様できるようにする。
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void registerStudent(Student student);
+
+  /**
+   * @return 受講生コースの情報をデータベースに登録する。
+   */
+  @Insert("INSERT students_courses values(#{id}, #{studentId}, #{courseName}, #{startDate}, #{endDate})")
+  void registerStudentCourse(StudentCourse studentCourse);
+}

--- a/src/main/java/raisetech/student/management/model/services/StudentService.java
+++ b/src/main/java/raisetech/student/management/model/services/StudentService.java
@@ -1,0 +1,39 @@
+package raisetech.student.management.model.services;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.repository.StudentRepository;
+
+@Service
+public class StudentService {
+
+  private final StudentRepository repository;
+
+  public StudentService(StudentRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<Student> searchStudentList() {
+    return repository.search();
+  }
+
+  public List<StudentCourse> searchStudentsCourseList() {
+    return repository.searchStudentsCourses();
+  }
+
+  // StudentControllerから送られてきたStudentとStudentCourseオブジェクトの情報をrepositoryに送る。
+  public void registerStudent(Student student, StudentCourse studentCourse) {
+    repository.registerStudent(
+        student); //まずstudentの情報をrepositoryのregisterStudentメソッドで登録（SQLでstudentsテーブルにINSERT）
+    // この時点で、StudentServiceから流れてきたstudentCourseには、フォームで入力されたcourseName以外の情報が入っていない。
+    studentCourse.setStudentId(
+        student.getId()); //studentCourseにstudentIdの数値（＝stundentテーブルのid）をセット。外部キー制約があるため、これはstudentCourseをstudents_coursesにINSERTする前に行う必要がある。
+    studentCourse.setStartDate(LocalDateTime.now()); //受講開始日時は、この瞬間のLocalDateTimeをセット
+    studentCourse.setEndDate(LocalDateTime.now().plusYears(1)); //受講終了日時は、受講開始日時の1年後をセット
+    repository.registerStudentCourse(
+        studentCourse); //studentCourseのすべての情報が出そろったら、repositoryのregisterStudentCourseメソッドで登録（SQLでstudents_coursesテーブルにINSERT）
+  }
+}

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h1>受講生登録フォーム</h1>
-<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+<form th:action="@{/students}" th:object="${studentDetail}" method="post">
   <div>
     <label for="fullname">氏名（必須）:</label>
     <input type="text" id="fullname" th:field="*{student.fullname}" required/>

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!--名前空間の宣言。thを持つ属性をThymeleafの属性として認識させることができる-->
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生登録フォーム</title>
+</head>
+<body>
+<h1>受講生登録フォーム</h1>
+<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="fullname">氏名（必須）:</label>
+    <input type="text" id="fullname" th:field="*{student.fullname}" required/>
+  </div>
+  <div>
+    <label for="furigana">ふりがな（必須）:</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム（任意）:</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
+  </div>
+  <div>
+    <label for="mail">メールアドレス（必須）:</label>
+    <input type="text" id="mail" th:field="*{student.mail}" required/>
+  </div>
+  <div>
+    <label for="address">住所（任意）:</label>
+    <input type="text" id="address" th:field="*{student.address}"/>
+  </div>
+  <div>
+    <label for="age">年齢（任意）:</label>
+    <input type="text" id="age" th:field="*{student.age}"/>
+  </div>
+  <div>
+    <label for="gender">性別（任意）:</label>
+    <input type="text" id="gender" th:field="*{student.gender}"/>
+  </div>
+  <div>
+    <label for="remark">備考（任意）:</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+  <div>
+    <label for="courseName">受講生コース:</label>
+    <input type="text" id="courseName" th:field="*{studentCourse[0].courseName}" required/>
+  </div>
+  <div>
+    <button type="submit">登録</button>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
**新カリキュラム第28回の課題（28_Thymeleafを使ったPOST処理）を以下のとおり実施いたしましたので、ご確認をお願いいたします。**
***
## 概要
**◆受講生登録フォームを表示し、フォームに入力した受講生情報および受講生コース情報をDBに登録する機能を実装しました。フォーム登録後は、自動的に受講生情報一覧が表示され、登録された受講生を確認することができます。**

**◆MySQLで事前に用意したデータテーブルは、以下の通りです**
1. students
![受講生](https://github.com/YaraiM/JavaNewChapter27Assignment/assets/153747182/c218a097-df04-4028-93b8-c56516ba0edc)

2. students_courses
　<img src="https://github.com/YaraiM/JavaNewChapter27Assignment/assets/153747182/a432bdd8-7317-4dfd-be57-143d6f976801" width="70%">

***
 
## 動作確認

**1. パスとして/students/newを指定すると、ブラウザに受講生登録フォームが表示されます。ここに、受講生情報と受講するコース名を入力し、登録ボタンを押すと、DBに受講生情報と受講生コース情報が登録されます。**

<img src="https://github.com/YaraiM/JavaNewChapter28Assignment/assets/153747182/bd9ca35a-fee0-4aaf-8154-d2b6c70edc0e" width="50%">
<img src="https://github.com/YaraiM/JavaNewChapter28Assignment/assets/153747182/bd44d345-c417-403b-8e5a-ceee235259cb"  width="50%">  

**2. 登録が正常に完了すると、ブラウザに受講生一覧が表示されます。入力した受講生情報が登録されていることが分かります。**
※IDはMySQLで主キーとしてオートインクリメントにより自動で付番しています。なお、IDの6～14が飛んでいますが、もともとここには動作確認中に入力した受講生情報が入っていました。このPRで動作を示す際には不要な情報であり、MySQL側でDELETE操作をして削除したため、数字が飛んでいます。主キーの数値を手動調整すると予期せぬ動作につながる恐れがあるため、数字をあえて飛んだ状態にしていることをご了承ください。

<img src="https://github.com/YaraiM/JavaNewChapter28Assignment/assets/153747182/28a4437c-d3d8-4b0e-b86e-f6ce648018b1"  width="100%">

**3. DBを確認すると、受講生情報、受講生コース情報ともに、正常に登録されていることが分かります。**
※students_coursesのstudent_idは、StudentServiceでstundentsのidと一致するように登録しています。
※students_coursesのstart_dateにはStudentServiceにおいて、処理が行われた瞬間のLacalDateTimeを登録しています。また、end_dateにはその1年後のLocalDateTimeを登録しています。

![入力した受講生情報がstudentsテーブルに追加](https://github.com/YaraiM/JavaNewChapter28Assignment/assets/153747182/3aa573ec-e3f7-4f35-aa6c-72600ee5d044)
<img src="https://github.com/YaraiM/JavaNewChapter28Assignment/assets/153747182/8954fb66-23fc-49b6-b376-e71d0af500d6"  width="75%">